### PR TITLE
feat(dashboard): add refresh callback to revalidate player data

### DIFF
--- a/app/routes/dashboard.player.$rsn/header.tsx
+++ b/app/routes/dashboard.player.$rsn/header.tsx
@@ -1,12 +1,8 @@
 import { Avatar, AvatarImage, AvatarFallback } from '@radix-ui/react-avatar';
-import { TooltipTrigger, TooltipContent } from '@radix-ui/react-tooltip';
-import { useFetcher } from '@remix-run/react';
 import { RefreshCw } from 'lucide-react';
 import FavouriteProfileButton from './favourite-button';
 import { Badge } from '~/components/ui/badge';
-import { Button } from '~/components/ui/button';
 import { Card, CardHeader } from '~/components/ui/card';
-import { Tooltip } from '~/components/ui/tooltip';
 import { PlayerData } from '~/~types/PlayerData';
 import { useTranslation } from 'react-i18next';
 import { formatDistance } from 'date-fns';
@@ -18,6 +14,7 @@ export interface HeaderComponentProps {
     refreshInfo: number;
     status: string;
   };
+    onSuccessfulRefresh?: () => void;
 }
 
 export default function Header(props: Readonly<HeaderComponentProps>) {
@@ -75,7 +72,7 @@ export default function Header(props: Readonly<HeaderComponentProps>) {
             </div>
           </div>
           <div className="flex gap-2 w-full sm:w-auto">
-            <RefreshProfileButton refreshInfo={props.data.refreshInfo} username={player.Username} />
+            <RefreshProfileButton refreshInfo={props.data.refreshInfo} username={player.Username} onSuccessfulRefresh={props.onSuccessfulRefresh} />
             <FavouriteProfileButton RSN={player.Username} />
           </div>
         </div>

--- a/app/routes/dashboard.player.$rsn/refresh-button.tsx
+++ b/app/routes/dashboard.player.$rsn/refresh-button.tsx
@@ -11,6 +11,7 @@ import type { RefreshProfileResponse } from '~/~types/API';
 export interface RefreshProfileButtonProps {
   username: string;
   refreshInfo: number;
+  onSuccessfulRefresh?: () => void;
 }
 
 const MANUAL_REFRESH_COOLDOWN_MS = 5 * 60 * 1000;
@@ -43,6 +44,7 @@ export default function RefreshProfileButton(props: Readonly<RefreshProfileButto
 
       if (fetcher.data.success) {
         toast.success(t('pages.player_profile.refresh_success'));
+        props.onSuccessfulRefresh?.();
       } else {
         toast.error(t('pages.player_profile.refresh_failed'));
       }

--- a/app/routes/dashboard.player.$rsn/route.tsx
+++ b/app/routes/dashboard.player.$rsn/route.tsx
@@ -3,9 +3,9 @@ import {
   isRouteErrorResponse,
   MetaFunction,
   useLoaderData,
-  useLocation,
   useNavigation,
   useParams,
+  useRevalidator,
   useRouteError,
 } from '@remix-run/react';
 import PlayerNotFound from './not-found';
@@ -117,6 +117,7 @@ export default function PlayerProfile() {
   const { t } = useTranslation();
   const data = useLoaderData<typeof loader>();
   const params = useParams();
+  const revalidator = useRevalidator();
   const navigation = useNavigation();
   const isLoading = navigation.state === 'loading';
   const isNavigatingToSamePlayerRoute =
@@ -149,7 +150,7 @@ export default function PlayerProfile() {
 
   return (
     <div className="space-y-4 sm:space-y-6">
-      <Header data={data} />
+      <Header data={data} onSuccessfulRefresh={() => revalidator.revalidate()} />
 
       <Tabs defaultValue="overview" className="space-y-4 sm:space-y-6">
         <TabsList className="grid w-full grid-cols-3 h-auto">


### PR DESCRIPTION
Pass onSuccessfulRefresh callback from Header to RefreshProfileButton to trigger revalidation after a successful manual refresh. This ensures the player data stays up-to-date without a full page reload. Removed unused imports and cleaned up related components for better maintainability.