### PR TITLE
fix(skills): correctly categorize skills between 99 and 120 levels

### DIFF
--- a/app/routes/dashboard.player.$rsn/tabs/skills.tsx
+++ b/app/routes/dashboard.player.$rsn/tabs/skills.tsx
@@ -33,7 +33,7 @@ export default function SkillTab(props: Readonly<SkillsTabProps>) {
   const levelsToday = Object.values(stats.dailyLevels).reduce((a, b) => a + b, 0);
   const xpToday = Object.values(stats.dailyXP).reduce((a, b) => a + b, 0);
   const skillsLeftTo99 = player.Skills.Skills.filter((skill) => skill.Level < 99);
-  const skillsLeftTo120 = player.Skills.Skills.filter((skill) => skill.Level < 120);
+  const skillsLeftTo120 = player.Skills.Skills.filter((skill) => skill.Level < 120 && skill.Level >= 99);
   const skillsAt120 = player.Skills.Skills.filter((skill) => skill.Level === 120);
 
   return (


### PR DESCRIPTION
Filter skillsLeftTo120 to include only those with levels from 99 up to but not including 120, preventing overlap with skillsAt120. This change ensures accurate skill categorization and improves data consistency on the dashboard.