### PR TITLE
feat(players): add Hall of Fame and Recently Active cards

### DIFF
--- a/app/routes/dashboard.changelog/route.tsx
+++ b/app/routes/dashboard.changelog/route.tsx
@@ -15,6 +15,15 @@ interface ChangelogEntry {
 
 const changelogData: ChangelogEntry[] = [
   {
+    version: 'v0.4.1',
+    title: 'Players rework',
+    date: new Date('2025-07-19T00:56:00Z'),
+    changes: [
+      { type: 'feature', description: 'Add card to Players - "Hall of Fame"' },
+      { type: 'feature', description: 'Add card to Players - "Recently Active"' },
+    ],
+  },
+  {
     version: 'v0.4.0',
     title: 'The Changelog update',
     date: new Date('2025-07-19T00:35:00Z'),

--- a/app/routes/dashboard.players/hall-of-fame.tsx
+++ b/app/routes/dashboard.players/hall-of-fame.tsx
@@ -1,0 +1,62 @@
+import { useNavigate } from '@remix-run/react';
+import { Crown, Eye } from 'lucide-react';
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '~/components/ui/card';
+
+export interface HallOfFameProps {
+  mostViewed: {
+    playerId: string;
+    username: string;
+    viewCount: number;
+    totalLevel: bigint | null;
+  }[];
+}
+
+export default function HallOfFame(props: Readonly<HallOfFameProps>) {
+  const { mostViewed } = props;
+  const navigate = useNavigate();
+
+  return (
+    <Card className="animate-fade-in">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Crown className="h-5 w-5 text-primary" />
+          Hall of Fame
+        </CardTitle>
+        <CardDescription>Most viewed players of all time</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-4">
+          {mostViewed.length === 0 ? (
+            <div className="flex items-center justify-center h-40">
+              <p className="text-muted-foreground text-xl">Its lonely here...</p>
+            </div>
+          ) : (
+            mostViewed.map((player, index) => (
+              <div
+                key={player.username}
+                className="flex items-center justify-between p-3 rounded-lg bg-muted/50 hover:bg-muted cursor-pointer transition-colors"
+                onClick={() => navigate(`/dashboard/player/${player.username}`)}
+              >
+                <div className="flex items-center gap-3">
+                  <div className="flex items-center justify-center w-8 h-8 rounded-full bg-primary/10 text-primary font-bold">
+                    {index + 1}
+                  </div>
+                  <div>
+                    <h4 className="font-semibold">{player.username}</h4>
+                  </div>
+                </div>
+                <div className="text-right">
+                  <div className="flex items-center gap-1 text-sm font-medium">
+                    <Eye className="h-3 w-3" />
+                    {player.viewCount}
+                  </div>
+                  <p className="text-xs text-muted-foreground">Level {Number(player.totalLevel)}</p>
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/routes/dashboard.players/recent-players.tsx
+++ b/app/routes/dashboard.players/recent-players.tsx
@@ -1,0 +1,51 @@
+import { useNavigate } from '@remix-run/react';
+import { formatDistance } from 'date-fns';
+import { Clock } from 'lucide-react';
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '~/components/ui/card';
+
+export interface RecentPlayersProps {
+  recentlyActive: {
+    username: string;
+    lastUpdated: Date;
+    totalLevel: bigint;
+  }[];
+}
+
+export default function RecentPlayers(props: Readonly<RecentPlayersProps>) {
+  const { recentlyActive } = props;
+  const navigate = useNavigate();
+
+  const now = new Date();
+
+
+  return (
+    <Card className="animate-fade-in">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Clock className="h-5 w-5 text-primary" />
+          Recently Active
+        </CardTitle>
+        <CardDescription>Players who were active recently</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-4">
+          {recentlyActive.map((player, index) => (
+            <div
+              key={player.username}
+              className="flex items-center justify-between p-3 rounded-lg bg-muted/50 hover:bg-muted cursor-pointer transition-colors"
+              onClick={() => navigate(`/dashboard/player/${player.username}`)}
+            >
+              <div>
+                <h4 className="font-semibold">{player.username}</h4>
+              </div>
+              <div className="text-right">
+                <p className="text-sm font-medium">Level {Number(player.totalLevel)}</p>
+                <p className="text-xs text-muted-foreground">{formatDistance(now, player.lastUpdated, { includeSeconds: true })}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/routes/dashboard.players/route.tsx
+++ b/app/routes/dashboard.players/route.tsx
@@ -1,25 +1,35 @@
-import { LoaderFunctionArgs } from '@remix-run/node';
 import { useLoaderData, useNavigate } from '@remix-run/react';
-import { TrendingUp, Eye, Trophy } from 'lucide-react';
+import { Clock } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import { Badge } from '~/components/ui/badge';
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '~/components/ui/card';
-import { getHighestTotalLevelPlayers, getMostViewedPlayers } from '~/~models/player.server';
+import {
+  getHighestTotalLevelPlayers,
+  getMostRecentlyUpdatedPlayers,
+  getMostViewedPlayers,
+} from '~/~models/player.server';
+import HallOfFame from './hall-of-fame';
+import RecentPlayers from './recent-players';
 
 export async function loader() {
-  const [mostViewed, topPlayers] = await Promise.all([
+  const [mostViewed, topPlayers, recentlyUpdated] = await Promise.all([
     getMostViewedPlayers(),
     getHighestTotalLevelPlayers(),
+    getMostRecentlyUpdatedPlayers(),
   ]);
 
   return {
     mostViewed,
     topPlayers,
+    recentlyUpdated,
   };
 }
 
+{
+  /* TODO add translation */
+}
+
 export default function Players() {
-  const { mostViewed, topPlayers } = useLoaderData<typeof loader>();
+  const { mostViewed, topPlayers, recentlyUpdated } = useLoaderData<typeof loader>();
   const { t } = useTranslation();
   const navigate = useNavigate();
 
@@ -30,80 +40,10 @@ export default function Players() {
         <p className="text-muted-foreground">{t('pages.players.description')}</p>
       </div>
 
-      <Card className="animate-fade-in">
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <Eye className="h-5 w-5 text-primary" />
-            {t('pages.players.most_searched.title')}
-          </CardTitle>
-          <CardDescription>{t('pages.players.most_searched.description')}</CardDescription>
-        </CardHeader>
-        <CardContent>
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
-            {mostViewed.map((player, index) => (
-              <Card
-                key={player.username}
-                className="transition-smooth hover:shadow-md cursor-pointer animate-fade-in hover:scale-105"
-                style={{ animationDelay: `${index * 0.05}s` }}
-                onClick={() => navigate(`/dashboard/player/${player.username}`)}
-              >
-                <CardContent className="p-4">
-                  <div className="flex items-center justify-between mb-2">
-                    <h3 className="font-semibold">{player.username}</h3>
-                  </div>
-                  <div className="space-y-1 text-sm text-muted-foreground">
-                    <div className="flex justify-between">
-                      <span>{t('pages.players.total_level')}</span>
-                      <span className="font-medium">{Number(player.totalLevel)}</span>
-                    </div>
-                    <div className="flex justify-between items-center">
-                      <span>{t('pages.players.most_searched.profile_views')}</span>
-                      <div className="flex items-center gap-1">
-                        <Eye className="h-3 w-3" />
-                        <span className="font-medium">{player.viewCount}</span>
-                      </div>
-                    </div>
-                  </div>
-                </CardContent>
-              </Card>
-            ))}
-          </div>
-        </CardContent>
-      </Card>
-
-      <Card className="animate-fade-in">
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <Trophy className="h-5 w-5 text-primary" />
-            {t('pages.players.top_players.title')}
-          </CardTitle>
-          <CardDescription>{t('pages.players.top_players.description')}</CardDescription>
-        </CardHeader>
-        <CardContent>
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
-            {topPlayers.map((player, index) => (
-              <Card
-                key={player.username}
-                className="transition-smooth hover:shadow-md cursor-pointer animate-fade-in hover:scale-105"
-                style={{ animationDelay: `${index * 0.05}s` }}
-                onClick={() => navigate(`/dashboard/player/${player.username}`)}
-              >
-                <CardContent className="p-4">
-                  <div className="flex items-center justify-between mb-2">
-                    <h3 className="font-semibold">{player.username}</h3>
-                  </div>
-                  <div className="space-y-1 text-sm text-muted-foreground">
-                    <div className="flex justify-between">
-                      <span>{t('pages.players.total_level')}</span>
-                      <span className="font-medium">{Number(player.totalLevel)}</span>
-                    </div>
-                  </div>
-                </CardContent>
-              </Card>
-            ))}
-          </div>
-        </CardContent>
-      </Card>
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
+        <HallOfFame mostViewed={mostViewed} />
+        <RecentPlayers recentlyActive={recentlyUpdated}/>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Introduce two new player cards to the Players dashboard: "Hall of Fame" showcasing top players by total level, and "Recently Active" displaying players with recent updates. Update loader to fetch recently updated players and refactor UI to use dedicated components for these sections.

chore(changelog): add v0.4.1 entry for players rework

Document the new features added in version v0.4.1, highlighting the Players rework with the addition of "Hall of Fame" and "Recently Active" cards to improve player visibility and engagement.