### PR TITLE
feat: add production Docker setup and GitHub deploy workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,20 @@
+# Ignore dependencies
+node_modules
+.pnpm
+
+# Ignore git & build files
+.git
+.gitignore
+Dockerfile
+docker-compose*.yml
+
+# Ignore environment files
+.env
+.env.*
+secrets/
+
+# Ignore logs
+*.log
+
+# Ignore OS files
+.DS_Store

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,41 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Enable pnpm
+        run: |
+          corepack enable
+          corepack prepare pnpm@latest --activate
+
+      - name: Copy files to VPS
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: ${{ secrets.VPS_USER }}
+          key: ${{ secrets.VPS_KEY }}
+          source: "."
+          target: "/home/deploy/rsx"
+          strip_components: 1
+
+      - name: Deploy via SSH
+        uses: appleboy/ssh-action@v0.1.10
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: ${{ secrets.VPS_USER }}
+          key: ${{ secrets.VPS_KEY }}
+          script: |
+            cd ~/rsx
+            docker compose -f docker-compose.prod.yml down
+            docker compose -f docker-compose.prod.yml up --build -d
+            docker compose exec app pnpm prisma migrate deploy

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ node_modules
 /.cache
 /build
 .env
+.env.production
+/secrets
 
 /generated/prisma
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM node:20
+
+RUN corepack enable && corepack prepare pnpm@latest --activate
+
+ENV PNPM_HOME="/root/.local/share/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+
+RUN pnpm add -g pm2
+
+WORKDIR /app
+
+COPY package.json pnpm-lock.yaml ./
+
+ENV PNPM_SKIP_VERIFY_PEER_DEP=1
+ENV HUSKY=0
+RUN pnpm install --frozen-lockfile --prefer-offline --ignore-scripts
+
+COPY . .
+
+RUN pnpm rebuild prisma && pnpm exec prisma generate
+
+RUN pnpm build
+
+EXPOSE 80
+CMD ["pm2-runtime", "ecosystem.config.js"]

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 services:
   postgres:
     image: postgres:16

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,37 @@
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    restart: always
+    ports:
+      - "80:80"
+    env_file: .env.production
+    secrets:
+      - postgres_password
+    depends_on:
+      - postgres
+      - redis
+
+  postgres:
+    image: postgres:16
+    restart: always
+    environment:
+      POSTGRES_USER: nexus
+      POSTGRES_PASSWORD_FILE: /run/secrets/postgres_password
+      POSTGRES_DB: nexusdb
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    secrets:
+      - postgres_password
+
+  redis:
+    image: redis:7
+    restart: always
+
+secrets:
+  postgres_password:
+    file: ./secrets/postgres_password.txt
+
+volumes:
+  pgdata:

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -1,0 +1,13 @@
+module.exports = {
+  apps: [
+    {
+      name: 'rsx',
+      script: 'pnpm',
+      args: 'start',
+      env: {
+        NODE_ENV: 'production',
+        PORT: 80,
+      },
+    },
+  ],
+};


### PR DESCRIPTION
Add a Dockerfile and docker-compose.prod.yml to enable containerized production deployment with Node 20, pm2 process manager, and Prisma setup. Configure environment and secrets handling for secure database access.

Introduce a GitHub Actions workflow to automate deployment on push to main branch. The workflow builds and deploys the app to a VPS via SSH, restarting containers and running Prisma migrations.

Update .dockerignore and .gitignore to exclude sensitive files, logs, and unnecessary build artifacts, improving build context and security.

Simplify docker-compose.dev.yml by removing version declaration for compatibility. Add ecosystem.config.js for pm2 process configuration.