### PR TITLE
chore: update ecosystem config for production deployment

### DIFF
--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -1,11 +1,14 @@
 module.exports = {
   apps: [
     {
-      name: 'rsx',
-      script: 'pnpm',
-      args: 'start',
+      name: "rsx",
+      script: "node",
+      args: 'build/server/index.js',
+      instances: 1,
+      autorestart: true,
+      watch: false,
       env: {
-        NODE_ENV: 'production',
+        NODE_ENV: "production",
         PORT: 80,
       },
     },


### PR DESCRIPTION
Change the script to run the built server file directly with node instead of using pnpm start. Set instances to 1, enable autorestart, and disable watch to optimize production environment settings.