### PR TITLE
chore(docker): copy production env file in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,8 @@ RUN pnpm install --frozen-lockfile --prefer-offline --ignore-scripts
 
 COPY . .
 
+COPY .env.production .env
+
 RUN pnpm rebuild prisma && pnpm exec prisma generate
 
 RUN pnpm build


### PR DESCRIPTION
Add copying of .env.production to .env inside the Docker image to ensure the correct environment variables are used during build and runtime. This change improves consistency and prevents configuration issues in production deployments.