### PR TITLE
feat(docker): parameterize environment variables and expose port

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,6 +36,18 @@ jobs:
           key: ${{ secrets.VPS_KEY }}
           script: |
             cd ~/rsx
+
+            echo "Generating .env.production..."
+            cat <<EOF > .env.production
+            DATABASE_URL=${{ secrets.DATABASE_URL }}
+            REDIS_URL=${{ secrets.REDIS_URL }}
+            NODE_ENV=production
+            PORT=80
+            EOF
+
+            echo "Starting Docker deployment..."
             docker compose -f docker-compose.prod.yml down
             docker compose -f docker-compose.prod.yml up --build -d
+
+            echo "Running Prisma migrate..."
             docker compose exec app pnpm prisma migrate deploy

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,15 @@
 FROM node:20
 
+ARG DATABASE_URL
+ARG REDIS_URL
+ARG NODE_ENV=production
+ARG PORT=80
+
+ENV DATABASE_URL=${DATABASE_URL}
+ENV REDIS_URL=${REDIS_URL}
+ENV NODE_ENV=${NODE_ENV}
+ENV PORT=${PORT}
+
 RUN corepack enable && corepack prepare pnpm@latest --activate
 
 ENV PNPM_HOME="/root/.local/share/pnpm"
@@ -21,5 +31,6 @@ RUN pnpm rebuild prisma && pnpm exec prisma generate
 
 RUN pnpm build
 
-EXPOSE 80
+EXPOSE ${PORT}
+
 CMD ["pm2-runtime", "ecosystem.config.js"]


### PR DESCRIPTION
Add ARG and ENV instructions for DATABASE_URL, REDIS_URL, NODE_ENV, and PORT in the Dockerfile to enable flexible configuration at build and runtime. Replace hardcoded port 80 with dynamic PORT exposure.

Update deploy workflow to generate .env.production dynamically with secrets and start Docker deployment accordingly. This improves configuration and deployment flexibility.