### PR TITLE
fix(docker): remove copying of .env.production file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,6 @@ RUN pnpm install --frozen-lockfile --prefer-offline --ignore-scripts
 
 COPY . .
 
-COPY .env.production .env
-
 RUN pnpm rebuild prisma && pnpm exec prisma generate
 
 RUN pnpm build


### PR DESCRIPTION
Remove the step that .env.production to .env in the Dockerfile. This change prevents sensitive environment variables from being included in the Docker image, improving security and ensuring that environment configuration is managed outside the image.