### PR TITLE
feat(meta): add theme-color and improve player meta tags

### DIFF
--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -12,6 +12,7 @@ export const meta: MetaFunction = () => [
   { property: 'og:type', content: 'website' },
   { property: 'og:image', content: 'https://rsx.lol/logo.png' },
   { property: 'og:url', content: 'https://rsx.lol' },
+  { name: 'theme-color', content: '#a29bf4' },
 ];
 
 export async function loader() {

--- a/app/routes/dashboard.player.$rsn/route.tsx
+++ b/app/routes/dashboard.player.$rsn/route.tsx
@@ -31,23 +31,19 @@ import { PlayerProfileSkeleton } from './skeleton';
 import { useTranslation } from 'react-i18next';
 import { PlayerDataFetcher } from '~/~models/data-fetcher.server';
 
-export const meta: MetaFunction = () => {
+export const meta: MetaFunction = ({ data }) => {
   const params = useParams();
   const rsn = params.rsn ?? 'Player';
+
   return [
     { title: `${rsn} | RSX` },
-    {
-      name: 'description',
-      content: `View ${rsn}'s Runescape 3 stats, progress, and profile on RSX.`,
-    },
+    { name: 'description', content: `View ${rsn}'s Runescape 3 stats, progress, and profile on RSX.` },
+    { name: 'theme-color', content: '#a29bf4' },
     { property: 'og:title', content: `${rsn} | RSX` },
-    {
-      property: 'og:description',
-      content: `View ${rsn}'s Runescape 3 stats, progress, and profile on RSX.`,
-    },
+    { property: 'og:description', content: `View ${rsn}'s Runescape 3 stats, progress, and profile on RSX.` },
     { property: 'og:type', content: 'profile' },
-    { property: 'og:image', content: 'https://rsx.lol/logo.png' },
-    { property: 'og:url', content: 'https://rsx.lol' },
+    { property: 'og:image', content: `https://secure.runescape.com/m=avatar-rs/${rsn}/chat.png` },
+    { property: 'og:url', content: `https://rsx.lol/dashboard/player/${encodeURIComponent(rsn)}` },
   ];
 };
 

--- a/app/routes/dashboard.tsx
+++ b/app/routes/dashboard.tsx
@@ -16,6 +16,7 @@ export const meta: MetaFunction = () => [
     property: 'og:description',
     content: 'Your comprehensive Runescape 3 tracking and toolkit service',
   },
+  { name: 'theme-color', content: '#a29bf4' },
   { property: 'og:type', content: 'website' },
   { property: 'og:image', content: 'https://rsx.lol/logo.png' },
   { property: 'og:url', content: 'https://rsx.lol' },


### PR DESCRIPTION
Add a theme-color meta tag with a consistent purple shade (#a29bf4) across the main index, dashboard, and player routes to enhance browser UI theming. Update the player route meta to dynamically set Open Graph image and URL based on the player RSN, improving social sharing previews and accuracy. These changes improve visual consistency and metadata relevance for better user experience and SEO.